### PR TITLE
删除监听器防止内存泄漏

### DIFF
--- a/src/RichMarker.js
+++ b/src/RichMarker.js
@@ -1095,6 +1095,11 @@ var BMapLib = window.BMapLib = BMapLib || {};
         if (!dom) {
             return;
         }
+        //删除_setEventDispatch中残留的监听器
+        var events = ['onclick','ontouchend','ondblclick','onmouseover','onmouseout','onmouseup','ondragging','onmousedown'];
+        for (var i=0;i<events.length;i++){
+            baidu.un(dom,events[i]);
+        }
         var attrs = dom.attributes,
             name = "";
         if (attrs) {


### PR DESCRIPTION
最近做了一个配送相关的网页，使用RichMarker作为配送员在地图上的标记。每隔十几秒获取一次配送员的位置，并刷新配送员RichMarker的位置。
使用之后发现每次刷新位置后都会有内存泄漏，连续开着一晚上不管会导致网页占用1G多的内存。
由于这种使用方法可能比较少，上网没有找到相关问题的解决方法，无奈之下看了源码，因为并太懂前端，所以按照自己的理解将_setEventDispatch中绑定的事件在删除标记的时候一起删除，内存泄漏就没有了。
       作为baiduMap的忠实用户，希望能更新RichMarker的代码，以后使用更方便